### PR TITLE
move_strを6文字に制限

### DIFF
--- a/FGtoGikouKihu/main.cpp
+++ b/FGtoGikouKihu/main.cpp
@@ -278,7 +278,7 @@ int read_game_info(std::vector<filepath>& list_) {
 			}//end of summary
 			 //moves
 			else if (line[0] == '+' || line[0] == '-') {
-				string move_str = line.substr(1);
+				string move_str = line.substr(1, 6);
 				gd.moves.push_back(move_str);
 				gd.plys++;
 				_ASSERT(gd.plys <= 257);


### PR DESCRIPTION
floodgateの棋譜で稀に「+1716FU '** 0 +1716FU」のように指し手の行にコメントが入っていることがあるようでしたので、line.substr(1)をline.substr(1, 6)に修正してみました。
（例）http://wdoor.c.u-tokyo.ac.jp/shogi/LATEST/2017/05/23/wdoor+floodgate-300-10F+Marin+Titanda_L+20170523073004.csa
